### PR TITLE
Fixes to build against 4.13.x kernels

### DIFF
--- a/r2k.c
+++ b/r2k.c
@@ -46,6 +46,7 @@ static struct device *r2k_dev_ph;
 static struct class *r2k_class;
 static struct cdev *r2k_dev;
 static dev_t devno;
+unsigned long stack_guard_gap = STACK_GUARD_GAP;
 
 static struct r2k_map g_r2k_map = {
 	{0, 0},

--- a/r2k.c
+++ b/r2k.c
@@ -634,16 +634,8 @@ static long io_ioctl (struct file *file, unsigned int cmd,
 #if defined(CONFIG_X86_32) || defined(CONFIG_X86_64)
 		regs.cr0 = native_read_cr0 ();
 		regs.cr2 = native_read_cr2 ();
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 13, 0)
 		regs.cr3 = native_read_cr3 ();
-#else
-		regs.cr3 = __native_read_cr3 ();
-#endif
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 9, 0)
-		regs.cr4 = native_read_cr4_safe ();
-#else
 		regs.cr4 = native_read_cr4 ();
-#endif
 #ifdef CONFIG_X86_64
 		regs.cr8 = native_read_cr8 ();
 #endif

--- a/r2k.c
+++ b/r2k.c
@@ -46,8 +46,6 @@ static struct device *r2k_dev_ph;
 static struct class *r2k_class;
 static struct cdev *r2k_dev;
 static dev_t devno;
-unsigned long stack_guard_gap = 256UL<<PAGE_SHIFT;
-
 
 static struct r2k_map g_r2k_map = {
 	{0, 0},
@@ -196,7 +194,7 @@ static int write_vmareastruct (struct vm_area_struct *vma, struct mm_struct *mm,
 
 	data->vmareastruct[counter]   = vma->vm_start;
 	data->vmareastruct[counter+1] = vma->vm_end;
-#if LINUX_VERSION_CODE > KERNEL_VERSION(2,6,38) && LINUX_VERSION_CODE < KERNEL_VERSION(4, 12, 6)
+#if LINUX_VERSION_CODE > KERNEL_VERSION(2,6,38) && LINUX_VERSION_CODE < KERNEL_VERSION(4, 11, 7)
 	if (stack_guard_page_start (vma, vma->vm_start)) {
 		data->vmareastruct[counter] += PAGE_SIZE;
 	}
@@ -209,7 +207,7 @@ static int write_vmareastruct (struct vm_area_struct *vma, struct mm_struct *mm,
 			data->vmareastruct[counter] += PAGE_SIZE;
 		}
 	}
-#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 6)
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 7)
 	data->vmareastruct[counter] = vm_start_gap(vma);
 #endif
 	data->vmareastruct[counter+2] = vma->vm_flags;
@@ -434,19 +432,13 @@ static long io_ioctl (struct file *file, unsigned int cmd,
 			void *kaddr;
 			int bytes;
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4,9,2)
-			ret = get_user_pages (task, task->mm, m_transf->addr, 1,
+			ret = get_user_pages_wrapper(task, task->mm, m_transf->addr, 1,
 									0,
 									0,
 									&pg,
+									NULL,
 									NULL);
-#else
-			ret = get_user_pages (task, task->mm, m_transf->addr, 1,
-									0,
-									&pg,
-									0,
-									NULL);
-#endif
+
 			if (!ret) {
 				pr_info ("%s: could not retrieve page"
 							"from pid (%d)\n",
@@ -642,12 +634,12 @@ static long io_ioctl (struct file *file, unsigned int cmd,
 #if defined(CONFIG_X86_32) || defined(CONFIG_X86_64)
 		regs.cr0 = native_read_cr0 ();
 		regs.cr2 = native_read_cr2 ();
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 13, 1)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 13, 0)
 		regs.cr3 = native_read_cr3 ();
 #else
 		regs.cr3 = __native_read_cr3 ();
 #endif
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 9, 1)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 9, 0)
 		regs.cr4 = native_read_cr4_safe ();
 #else
 		regs.cr4 = native_read_cr4 ();

--- a/r2k.h
+++ b/r2k.h
@@ -9,6 +9,7 @@
 #endif
 
 #define R2_TYPE 0x69
+#define STACK_GUARD_GAP 250UL<<PAGE_SHIFT
 
 /* Memory Part */
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,6,0)

--- a/r2k.h
+++ b/r2k.h
@@ -20,12 +20,10 @@
 	get_user_pages_remote(tsk, mm, start, nr_pages, write, force, pages, vmas)
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,9,0) && LINUX_VERSION_CODE < KERNEL_VERSION(4,10,0)
 #define get_user_pages_wrapper(tsk, mm, start, nr_pages, write, force, pages, vmas, locked) \
-	get_user_pages_remote(tsk, mm, start, nr_pages, write|force, pages, vmas)
-	// write: FOLL_WRITE, force: FOLL_FORCE
+	get_user_pages_remote(tsk, mm, start, nr_pages, (write ? FOLL_WRITE : 0) | (force ? FOLL_FORCE, 0), pages, vmas)
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,10,0)
 #define get_user_pages_wrapper(tsk, mm, start, nr_pages, write, force, pages, vmas, locked) \
-	get_user_pages_remote(tsk, mm, start, nr_pages, write|force, pages, vmas, locked)
-	// write: FOLL_WRITE, force: FOLL_FORCE
+	get_user_pages_remote(tsk, mm, start, nr_pages, (write ? FOLL_WRITE : 0) | (force ? FOLL_FORCE : 0), pages, vmas, locked)
 #endif
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,6,0)

--- a/r2k.h
+++ b/r2k.h
@@ -99,6 +99,13 @@ extern int pg_dump (struct r2k_map *k_map);
 #define reg_size 8
 #endif
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 13, 0)
+#define native_read_cr3	__native_read_cr3
+#endif
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 9, 0)
+#define native_read_cr4	native_read_cr4_safe
+#endif
 
 struct r2k_control_reg {
 #if defined(CONFIG_X86_32) || defined(CONFIG_X86_64)

--- a/r2k.h
+++ b/r2k.h
@@ -20,9 +20,11 @@
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,9,0) && LINUX_VERSION_CODE < KERNEL_VERSION(4,10,0)
 #define get_user_pages_wrapper(tsk, mm, start, nr_pages, write, force, pages, vmas, locked) \
 	get_user_pages_remote(tsk, mm, start, nr_pages, write|force, pages, vmas)
+	// write: FOLL_WRITE, force: FOLL_FORCE
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,10,0)
 #define get_user_pages_wrapper(tsk, mm, start, nr_pages, write, force, pages, vmas, locked) \
 	get_user_pages_remote(tsk, mm, start, nr_pages, write|force, pages, vmas, locked)
+	// write: FOLL_WRITE, force: FOLL_FORCE
 #endif
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,6,0)

--- a/r2k.h
+++ b/r2k.h
@@ -11,8 +11,21 @@
 #define R2_TYPE 0x69
 
 /* Memory Part */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,6,0)
+#define get_user_pages_wrapper(tsk, mm, start, nr_pages, write, force, pages, vmas, locked) \
+	get_user_pages(tsk, mm, start, nr_pages, write, force, pages, vmas)
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,6,0) && LINUX_VERSION_CODE < KERNEL_VERSION(4,9,0)
+#define get_user_pages_wrapper(tsk, mm, start, nr_pages, write, force, pages, vmas, locked) \
+	get_user_pages_remote(tsk, mm, start, nr_pages, write, force, pages, vmas)
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,9,0) && LINUX_VERSION_CODE < KERNEL_VERSION(4,10,0)
+#define get_user_pages_wrapper(tsk, mm, start, nr_pages, write, force, pages, vmas, locked) \
+	get_user_pages_remote(tsk, mm, start, nr_pages, write|force, pages, vmas)
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,10,0)
+#define get_user_pages_wrapper(tsk, mm, start, nr_pages, write, force, pages, vmas, locked) \
+	get_user_pages_remote(tsk, mm, start, nr_pages, write|force, pages, vmas, locked)
+#endif
+
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,6,0)
-#define get_user_pages          get_user_pages_remote
 #define page_cache_release      put_page
 #endif
 


### PR DESCRIPTION
I'm not familiar with linux kernel internals at all, hence this PR is definitely a WIP.
Changing the backend to physical address mode triggers a crash, and most likely there will be more skeletons in the closet.